### PR TITLE
Note units for akka framesize

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -884,7 +884,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.akka.frameSize</code></td>
   <td>128</td>
   <td>
-    Maximum message size to allow in "control plane" communication; generally only applies to map
+    Maximum message size (in MB) to allow in "control plane" communication; generally only applies to map
     output size information sent between executors and the driver. Increase this if you are running
     jobs with many thousands of map and reduce tasks and see messages about the frame size.
   </td>


### PR DESCRIPTION
To stop anyone else wasting 15 minutes of their life Googling for this like I did. 1.4 docs specified the units, and they should continue to be there I think.